### PR TITLE
add expect_static_storage to big_into_small tests

### DIFF
--- a/test/cow-test.cpp
+++ b/test/cow-test.cpp
@@ -787,27 +787,6 @@ TEST_F(cow_test, insert_reallocation_throw) {
   }
 }
 
-TEST_F(cow_test, insert_no_reallocation_throw) {
-  container a;
-  a.reserve(10);
-  for (size_t i = 0; i < 5; ++i) {
-    a.push_back(i + 100);
-  }
-
-  {
-    immutable_guard ga(a);
-    element::set_swap_throw_countdown(1);
-    element::set_copy_throw_countdown(2);
-    EXPECT_THROW(a.insert(as_const(a).begin(), 42), std::runtime_error);
-  }
-
-  {
-    element::set_copy_throw_countdown(3);
-    element::set_swap_throw_countdown(3);
-    EXPECT_THROW(a.insert(as_const(a).begin(), 42), std::runtime_error);
-  }
-}
-
 TEST_F(cow_test, insert_copies) {
   container a;
   a.reserve(11);

--- a/test/cow-test.cpp
+++ b/test/cow-test.cpp
@@ -787,6 +787,27 @@ TEST_F(cow_test, insert_reallocation_throw) {
   }
 }
 
+TEST_F(cow_test, insert_no_reallocation_throw) {
+  container a;
+  a.reserve(10);
+  for (size_t i = 0; i < 5; ++i) {
+    a.push_back(i + 100);
+  }
+
+  {
+    immutable_guard ga(a);
+    element::set_swap_throw_countdown(1);
+    element::set_copy_throw_countdown(2);
+    EXPECT_THROW(a.insert(as_const(a).begin(), 42), std::runtime_error);
+  }
+
+  {
+    element::set_copy_throw_countdown(3);
+    element::set_swap_throw_countdown(3);
+    EXPECT_THROW(a.insert(as_const(a).begin(), 42), std::runtime_error);
+  }
+}
+
 TEST_F(cow_test, insert_copies) {
   container a;
   a.reserve(11);

--- a/test/small-object-test.cpp
+++ b/test/small-object-test.cpp
@@ -124,8 +124,6 @@ TEST_F(small_object_test, pop_back_big_into_small) {
   EXPECT_EQ(0, element::get_swap_counter());
 
   EXPECT_EQ(3, a.size());
-
-  expect_static_storage(a);
 }
 
 TEST_F(small_object_test, pop_back_big_into_small_single_user) {
@@ -695,8 +693,6 @@ TEST_F(small_object_test, clear_big_into_small) {
 
     EXPECT_TRUE(a.empty());
     EXPECT_EQ(0, a.size());
-
-    expect_static_storage(a);
   }
   element::assert_no_instances();
 }
@@ -997,8 +993,6 @@ TEST_F(small_object_test, erase_big_into_small) {
   auto it = a.erase(as_const(a).begin() + 1, as_const(a).end() - 1);
   EXPECT_EQ(as_const(a).begin() + 1, it);
   EXPECT_EQ(2, a.size());
-
-  expect_static_storage(a);
 }
 
 TEST_F(small_object_test, erase_big_into_small_single_user) {

--- a/test/small-object-test.cpp
+++ b/test/small-object-test.cpp
@@ -124,6 +124,8 @@ TEST_F(small_object_test, pop_back_big_into_small) {
   EXPECT_EQ(0, element::get_swap_counter());
 
   EXPECT_EQ(3, a.size());
+
+  expect_static_storage(a);
 }
 
 TEST_F(small_object_test, pop_back_big_into_small_single_user) {
@@ -693,6 +695,8 @@ TEST_F(small_object_test, clear_big_into_small) {
 
     EXPECT_TRUE(a.empty());
     EXPECT_EQ(0, a.size());
+
+    expect_static_storage(a);
   }
   element::assert_no_instances();
 }
@@ -993,6 +997,8 @@ TEST_F(small_object_test, erase_big_into_small) {
   auto it = a.erase(as_const(a).begin() + 1, as_const(a).end() - 1);
   EXPECT_EQ(as_const(a).begin() + 1, it);
   EXPECT_EQ(2, a.size());
+
+  expect_static_storage(a);
 }
 
 TEST_F(small_object_test, erase_big_into_small_single_user) {


### PR DESCRIPTION
В некоторых тестах нет проверки того, что в результате операции, требующей реаллокации (например, большой `erase`), большой вектор с `size() <= SMALL_SIZE` не становится маленьким.